### PR TITLE
Don't generate rooms on map edges

### DIFF
--- a/Karcero.Engine/Processors/RoomGenerator.cs
+++ b/Karcero.Engine/Processors/RoomGenerator.cs
@@ -29,7 +29,7 @@ namespace Karcero.Engine.Processors
                     //place the room
                     room.Row = cell.Row;
                     room.Column = cell.Column;
-                    if (room.Right > map.Width || room.Bottom > map.Height) continue; //out of bounds
+                    if (room.Column <= 0 || room.Right >= map.Width || room.Row <= 0 || room.Bottom >= map.Height) continue; //out of bounds
 
                     var cells = map.GetRoomCells(room).ToList();
 

--- a/Karcero.Tests/RoomGeneratorTests.cs
+++ b/Karcero.Tests/RoomGeneratorTests.cs
@@ -135,13 +135,13 @@ namespace Karcero.Tests
 
             foreach (var room in map.Rooms)
             {
-                Assert.IsTrue(map.GetCell(room.Row - 1, room.Column - 1) == null || 
+                Assert.IsTrue(map.GetCell(room.Row - 1, room.Column - 1) != null && 
                     map.GetCell(room.Row - 1, room.Column - 1).Terrain == TerrainType.Rock); //NW corner
-                Assert.IsTrue(map.GetCell(room.Row - 1, room.Right) == null ||
+                Assert.IsTrue(map.GetCell(room.Row - 1, room.Right) != null &&
                     map.GetCell(room.Row - 1, room.Right).Terrain == TerrainType.Rock); //NE corner
-                Assert.IsTrue(map.GetCell(room.Bottom, room.Column - 1) == null ||
+                Assert.IsTrue(map.GetCell(room.Bottom, room.Column - 1) != null &&
                     map.GetCell(room.Bottom, room.Column -1).Terrain == TerrainType.Rock); //SW corner
-                Assert.IsTrue(map.GetCell(room.Bottom, room.Right) == null ||
+                Assert.IsTrue(map.GetCell(room.Bottom, room.Right) != null &&
                     map.GetCell(room.Bottom, room.Right).Terrain == TerrainType.Rock); //SE corner
             }
 


### PR DESCRIPTION
- Forces a minimum one-cell padding between rooms and map edges
- Updates room generator test to enforce the constraint

I made this change so that I could ensure I could place walls around all my generated rooms, but I feel like this would be a useful constraint on room generation for most games (e.g., to make it easier to do bounds checks during actor movement).
